### PR TITLE
Add Arduino irrigation sketch

### DIFF
--- a/Arduino-laistymo-sistema.ino
+++ b/Arduino-laistymo-sistema.ino
@@ -1,0 +1,38 @@
+// Arduino-based irrigation system for greenhouse with soil moisture sensor and pump control.
+
+const int pumpPin = 4;          // Controls MOSFET gate for the pump
+const int sensorPowerPin = 5;   // Powers the moisture sensor
+const int sensorPin = 6;        // Reads digital output from the moisture sensor
+
+const unsigned long pumpRunTime = 5000;    // Pump run time in milliseconds
+const unsigned long readingInterval = 60000; // Time between moisture checks in milliseconds
+
+void setup() {
+  pinMode(pumpPin, OUTPUT);
+  digitalWrite(pumpPin, LOW); // Ensure pump is off
+
+  pinMode(sensorPowerPin, OUTPUT);
+  digitalWrite(sensorPowerPin, LOW); // Sensor off by default to reduce corrosion
+
+  pinMode(sensorPin, INPUT);
+}
+
+void loop() {
+  // Power on the moisture sensor
+  digitalWrite(sensorPowerPin, HIGH);
+  delay(10); // Allow sensor to stabilize
+
+  int moistureState = digitalRead(sensorPin);
+
+  // Power off the sensor after reading
+  digitalWrite(sensorPowerPin, LOW);
+
+  // For LM393-based sensors: HIGH = dry, LOW = wet (adjust as needed)
+  if (moistureState == HIGH) {
+    digitalWrite(pumpPin, HIGH); // Activate pump
+    delay(pumpRunTime);
+    digitalWrite(pumpPin, LOW);  // Deactivate pump
+  }
+
+  delay(readingInterval);
+}


### PR DESCRIPTION
## Summary
- add a simple Arduino sketch to power a soil moisture sensor, read its digital output, and drive a pump through a MOSFET

## Testing
- `arduino-cli version` *(fails: command not found)*

------
https://chatgpt.com/codex/tasks/task_e_68923e37ca188333a421bfe2168b6e78